### PR TITLE
Fix MIME type when requesting an export

### DIFF
--- a/src/Microsoft.Azure.IIoT.OpcUa/cli/Program.cs
+++ b/src/Microsoft.Azure.IIoT.OpcUa/cli/Program.cs
@@ -446,7 +446,7 @@ Operations (Mutually exclusive):
                 new ConsoleEmitter(), new LimitingScheduler(), logger) {
                 ExportIdleTime = TimeSpan.FromMilliseconds(1)
             };
-            var id = await exporter.StartModelExportAsync(endpoint, "application/ua-json");
+            var id = await exporter.StartModelExportAsync(endpoint, ContentEncodings.MimeTypeUaJson);
             await Task.Delay(TimeSpan.FromMinutes(10));
             await exporter.StopModelExportAsync(id);
         }


### PR DESCRIPTION
Before the fix, the MIME requested was `application/ua-json`
but the right one would be `application/ua+json`. After the fix
the right MIME is referred to from the defined constants.